### PR TITLE
follow the same API as the other boolops

### DIFF
--- a/geo/src/algorithm/spade_boolops/trait_def.rs
+++ b/geo/src/algorithm/spade_boolops/trait_def.rs
@@ -29,30 +29,30 @@ where
     Self: Contains<Point<T>> + Scale<T> + Sized,
 {
     fn boolop<F: Fn(&Triangle<T>) -> bool>(
-        p1: &Self,
+        &self,
         p2: &Self,
         op_type: OpType,
         op_pred: F,
     ) -> SpadeBoolopsResult<T>;
 
     #[must_use = "Use the difference of these two geometries by binding the result to a variable! (`let result = ...`)"]
-    fn difference(p1: &Self, p2: &Self) -> SpadeBoolopsResult<T> {
-        Self::boolop(p1, p2, OpType::Difference, |tri| {
-            contains_triangle(p1, tri) && !contains_triangle(p2, tri)
+    fn difference(&self, p2: &Self) -> SpadeBoolopsResult<T> {
+        self.boolop(p2, OpType::Difference, |tri| {
+            contains_triangle(self, tri) && !contains_triangle(p2, tri)
         })
     }
 
     #[must_use = "Use the intersection of these two geometries by binding the result to a variable! (`let result = ...`)"]
-    fn intersection(p1: &Self, p2: &Self) -> SpadeBoolopsResult<T> {
-        Self::boolop(p1, p2, OpType::Intersection, |tri| {
-            contains_triangle(p1, tri) && contains_triangle(p2, tri)
+    fn intersection(&self, p2: &Self) -> SpadeBoolopsResult<T> {
+        Self::boolop(self, p2, OpType::Intersection, |tri| {
+            contains_triangle(self, tri) && contains_triangle(p2, tri)
         })
     }
 
     #[must_use = "Use the union of these two geometries by binding the result to a variable! (`let result = ...`)"]
-    fn union(p1: &Self, p2: &Self) -> SpadeBoolopsResult<T> {
-        Self::boolop(p1, p2, OpType::Union, |tri| {
-            contains_triangle(p1, tri) || contains_triangle(p2, tri)
+    fn union(&self, p2: &Self) -> SpadeBoolopsResult<T> {
+        self.boolop(p2, OpType::Union, |tri| {
+            contains_triangle(self, tri) || contains_triangle(p2, tri)
         })
     }
 }

--- a/geo/src/algorithm/spade_boolops/trait_impl.rs
+++ b/geo/src/algorithm/spade_boolops/trait_impl.rs
@@ -12,12 +12,12 @@ where
     T: SpadeTriangulationFloat,
 {
     fn boolop<F: Fn(&Triangle<T>) -> bool>(
-        p1: &Self,
+        &self,
         p2: &Self,
         _op_type: OpType,
         op_pred: F,
     ) -> SpadeBoolopsResult<T> {
-        vec![p1.clone(), p2.clone()]
+        vec![self.clone(), p2.clone()]
             .constrained_outer_triangulation(Default::default())
             .map_err(SpadeBoolopsError::TriangulationError)?
             .into_iter()
@@ -33,7 +33,7 @@ where
     T: SpadeTriangulationFloat,
 {
     fn boolop<F: Fn(&Triangle<T>) -> bool>(
-        p1: &Self,
+        &self,
         p2: &Self,
         op_type: OpType,
         op_pred: F,
@@ -58,7 +58,7 @@ where
             polys_with(mp1, move |p| mp2.iter().any(|o| p.intersects(o)))
         };
 
-        let p1_inter = intersecting_polys(p1, &p2.0);
+        let p1_inter = intersecting_polys(self, &p2.0);
         // we know p2 can only intersect polys in p1_inter
         let p2_inter = intersecting_polys(p2, &p1_inter);
 
@@ -80,10 +80,10 @@ where
         // - if we union , then we want to include non intersecting polys of the second argument
         //   multi polygon in the result
         let p1_non_inter = matches!(op_type, OpType::Union | OpType::Difference)
-            .then(|| non_intersecting_polys(p1, p2))
+            .then(|| non_intersecting_polys(self, p2))
             .unwrap_or_default();
         let p2_non_inter = matches!(op_type, OpType::Union)
-            .then(|| non_intersecting_polys(p2, p1))
+            .then(|| non_intersecting_polys(p2, self))
             .unwrap_or_default();
 
         // do a constrained triangulation and then stitch the triangles together


### PR DESCRIPTION
Uses &self instead of p1: &Self in trait definition

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
